### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: xenial
+dist: trusty
 group: edge
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ addons:
       - mysql-client-5.6
   hosts:
       - magento2.travis
+services:
+  - rabbitmq
+  - elasticsearch
 language: php
 php:
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 group: edge
 addons:
   apt:
@@ -13,6 +13,7 @@ language: php
 php:
   - 7.0
   - 7.1
+  - 7.2
 env:
   global:
     - COMPOSER_BIN_DIR=~/bin
@@ -24,6 +25,7 @@ env:
     - MAGENTO_VERSION=2.2
     - MAGENTO_VERSION=2.2 CODE_COVERAGE=1
     - MAGENTO_VERSION=2.3-develop
+    - MAGENTO_VERSION=2.3 CODE_COVERAGE=1
 matrix:
   allow_failures:
     - env: MAGENTO_VERSION=2.1-develop
@@ -38,6 +40,10 @@ matrix:
       env: MAGENTO_VERSION=2.2 CODE_COVERAGE=1
     - php: 7.1
       env: MAGENTO_VERSION=2.2
+    - php: 7.1
+      env: MAGENTO_VERSION=2.3
+    - php: 7.2
+      env: MAGENTO_VERSION=2.3 CODE_COVERAGE=1
 cache:
   apt: true
   directories: $HOME/.composer/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - MAGENTO_VERSION=2.1
     - MAGENTO_VERSION=2.2-develop
     - MAGENTO_VERSION=2.2
-    - MAGENTO_VERSION=2.2 CODE_COVERAGE=1
     - MAGENTO_VERSION=2.3-develop
     - MAGENTO_VERSION=2.3 CODE_COVERAGE=1
 matrix:
@@ -32,17 +31,17 @@ matrix:
     - env: MAGENTO_VERSION=2.2-develop
     - env: MAGENTO_VERSION=2.3-develop
   exclude:
-    - php: 7.1
-      env: MAGENTO_VERSION=2.1-develop
-    - php: 7.1
-      env: MAGENTO_VERSION=2.1
-    - php: 7.0
-      env: MAGENTO_VERSION=2.2 CODE_COVERAGE=1
-    - php: 7.1
-      env: MAGENTO_VERSION=2.2
-    - php: 7.1
-      env: MAGENTO_VERSION=2.3
     - php: 7.2
+      env: MAGENTO_VERSION=2.1-develop
+    - php: 7.2
+      env: MAGENTO_VERSION=2.1
+    - php: 7.2
+      env: MAGENTO_VERSION=2.2-develop
+    - php: 7.2
+      env: MAGENTO_VERSION=2.2
+    - php: 7.0
+      env: MAGENTO_VERSION=2.3-develop
+    - php: 7.0
       env: MAGENTO_VERSION=2.3 CODE_COVERAGE=1
 cache:
   apt: true

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,12 @@
     ],
     "require": {
         "php": ">=7",
-        "magento/framework": "^100|^101",
-        "magento/module-eav": "^100|^101"
+        "magento/framework": "^100|^101|^102",
+        "magento/module-eav": "^100|^101|^102"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.1",
-        "magento/module-catalog": "^101"
+        "magento/module-catalog": "^101|^102|^103"
     },
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. This also adds support for a Magento 2.3 integration test in Travis. Previously this was run against 2.3-develop and would not matter if it failed