### PR TITLE
Improve ability to re-run integration tests

### DIFF
--- a/Test/Integration/Model/AttributeSetRepositoryTest.php
+++ b/Test/Integration/Model/AttributeSetRepositoryTest.php
@@ -725,6 +725,15 @@ class AttributeSetRepositoryTest extends \PHPUnit\Framework\TestCase
 
         $entityTypeId = self::getEntityTypeId($attributeSet->getEntityTypeCode());
         $attributeSetId = $attributeSetCodeRepository->getAttributeSetId($entityTypeId, $attributeSet->getAttributeSetCode());
+        if ($attributeSetId === null) {
+            $searchCriteria = $objectManager->create(SearchCriteriaBuilder::class)->create();
+            foreach ($attributeSetRepository->getList($searchCriteria)->getItems() as $possibleAttributeSet) {
+                if ($possibleAttributeSet->getAttributeSetName() === $attributeSet->getName()) {
+                    $attributeSetId = $possibleAttributeSet->getAttributeSetId();
+                    break;
+                }
+            }
+        }
         if ($attributeSetId !== null) {
             $attributeSetRepository->deleteById($attributeSetId);
         }
@@ -798,9 +807,10 @@ class AttributeSetRepositoryTest extends \PHPUnit\Framework\TestCase
         $productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
 
         try {
+            $productRepository->deleteById($product->getSku());
             $productRepository->save($product);
         } catch (StateException $e) {
-            
+        } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
         }
     }
 

--- a/Test/Integration/Model/AttributeSetRepositoryTest.php
+++ b/Test/Integration/Model/AttributeSetRepositoryTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace SnowIO\AttributeSetCode\Test\Integration\Model;
 
+use Magento\Framework\App\Area;
 use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Api\ProductRepositoryInterface;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
@@ -806,12 +807,24 @@ class AttributeSetRepositoryTest extends \PHPUnit\Framework\TestCase
         /** @var ProductRepositoryInterface $productRepository */
         $productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
 
+        /** @var \Magento\Framework\Registry $state */
+        $registry = Bootstrap::getObjectManager()->get(\Magento\Framework\Registry::class);
+        $currentSecure = $registry->registry('isSecureArea');
+        $registry->unregister('isSecureArea');
+        $registry->register('isSecureArea', true);
+
         try {
             $productRepository->deleteById($product->getSku());
-            $productRepository->save($product);
-        } catch (StateException $e) {
         } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {
         }
+
+        try {
+            $productRepository->save($product);
+        } catch (StateException $e) {
+        }
+
+        $registry->unregister('isSecureArea');
+        $registry->register('isSecureArea', $currentSecure);
     }
 
     private static function saveNewSizeAttribute()

--- a/Test/Integration/Model/AttributeSetRepositoryTest.php
+++ b/Test/Integration/Model/AttributeSetRepositoryTest.php
@@ -807,7 +807,7 @@ class AttributeSetRepositoryTest extends \PHPUnit\Framework\TestCase
         $productRepository = Bootstrap::getObjectManager()->get(ProductRepositoryInterface::class);
 
         try {
-            $productRepository->deleteById($product->getSku());
+            //$productRepository->deleteById($product->getSku());
             $productRepository->save($product);
         } catch (StateException $e) {
         } catch (\Magento\Framework\Exception\NoSuchEntityException $exception) {


### PR DESCRIPTION
Cleans up a bit better in some scenarios, when tests fail halfway through you had to tank your whole integration test instance

I was seeing products getting confused having references to deleted attribute set ids

```
1) SnowIO\AttributeSetCode\Test\Integration\Model\AttributeSetRepositoryTest::testMoveAttributesToNewGroupWithAssociatedConfigurableProduct
Magento\Framework\Exception\NoSuchEntityException: No such entity with id = 15
```

Improve the deletion of attribute sets with an extra back up catch all, and delete products before saving them.